### PR TITLE
feat: 2024-06 kind, taskfile.dev, make is sunset

### DIFF
--- a/Office_L.json
+++ b/Office_L.json
@@ -84,6 +84,13 @@
         "description": "マルチパラダイムプログラミング言語と認識されている。早い。学習難易度高め。正直ちょっと難しい。<br />see: <a href='https://github.com/officel/byor/blob/main/radar/languages_frameworks/rust.md'>note</a>"
     },
     {
+        "name": "Task",
+        "ring": "adopt",
+        "quadrant": "tools",
+        "isNew": "TRUE",
+        "description": "Task (taskfile.dev) は GNU Make 代替のビルドツール。Make から順次移行中。 <br />see: <a href='https://github.com/officel/byor/blob/main/radar/tools/taskfiledev.md'>note</a>"
+    },
+    {
         "name": "ansible",
         "ring": "adopt",
         "quadrant": "tools",
@@ -126,6 +133,13 @@
         "description": "LLのひとつ？ JavaScript のランタイムは今のところ nodejs 一択なんだけど、Deno と Bun の追い上げにも注意。<br />see: <a href='https://github.com/officel/byor/blob/main/radar/languages_frameworks/javascirpt.md'>note</a>"
     },
     {
+        "name": "kind",
+        "ring": "adopt",
+        "quadrant": "platforms",
+        "isNew": "TRUE",
+        "description": "Kubernetes in Docker. k8s をローカルの docker 上でマルチノードで動作させるツール。<br />see: <a href='https://github.com/officel/byor/blob/main/radar/platforms/kind.md'>note</a>"
+    },
+    {
         "name": "lint",
         "ring": "adopt",
         "quadrant": "techniques",
@@ -134,9 +148,9 @@
     },
     {
         "name": "make",
-        "ring": "trial",
+        "ring": "hold",
         "quadrant": "tools",
-        "isNew": "TRUE",
+        "isNew": "FALSE",
         "description": "GNU Make はソースコードから実行ファイルを生成するためのツール、ワークフローの古いやつ。 <br />see: <a href='https://github.com/officel/byor/blob/main/radar/tools/make.md'>note</a>"
     },
     {

--- a/gen_json.py
+++ b/gen_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import json
 import os

--- a/radar/platforms/kind.md
+++ b/radar/platforms/kind.md
@@ -1,0 +1,25 @@
+---
+byor:
+    "name": "kind"
+    "ring": "adopt"
+    "quadrant": "platforms"
+    "isNew": "TRUE"
+    "description": "\
+    Kubernetes in Docker. k8s をローカルの docker 上でマルチノードで動作させるツール。\
+    <br />see: <a href='https://github.com/officel/byor/blob/main/radar/platforms/kind.md'>note</a>\
+    "
+---
+
+# kind
+
+- [kind](https://kind.sigs.k8s.io/)
+- 久しぶりに k8s を触ることになって、ローカルで遊ぶ環境が欲しかったので導入
+- terraform で管理できるので便利
+
+## history
+
+### 2024-06
+
+- [terraform で kind を設定してみた](https://zenn.dev/terraform_jp/articles/2024-05-20_terraform_kind)
+- [ingress-nginx を kind にインストールしてみた](https://zenn.dev/terraform_jp/articles/2024-06-07_terraform_kind_ingress_nginx)
+- [Argo CD を kind にインストールして ingress-nginx でアクセスできるようにしてみた](https://zenn.dev/terraform_jp/articles/2024-06-12_terraform_kind_argocd)

--- a/radar/tools/make.md
+++ b/radar/tools/make.md
@@ -1,9 +1,9 @@
 ---
 byor:
     "name": "make"
-    "ring": "trial"
+    "ring": "hold"
     "quadrant": "tools"
-    "isNew": "TRUE"
+    "isNew": "FALSE"
     "description": "\
     GNU Make はソースコードから実行ファイルを生成するためのツール、ワークフローの古いやつ。
     <br />see: <a href='https://github.com/officel/byor/blob/main/radar/tools/make.md'>note</a>\
@@ -16,6 +16,10 @@ byor:
 - 方言がいろいろあるけど GNU 版を使っておけばひとまず安心（`man make`）
 
 ## history
+
+### 2024-06
+
+- Task に移行中
 
 ### 2024-04
 

--- a/radar/tools/taskfiledev.md
+++ b/radar/tools/taskfiledev.md
@@ -1,0 +1,22 @@
+---
+byor:
+    "name": "Task"
+    "ring": "adopt"
+    "quadrant": "tools"
+    "isNew": "TRUE"
+    "description": "\
+    Task (taskfile.dev) は GNU Make 代替のビルドツール。Make から順次移行中。
+    <br />see: <a href='https://github.com/officel/byor/blob/main/radar/tools/taskfiledev.md'>note</a>\
+    "
+---
+
+# task
+
+- [Home | Task](https://taskfile.dev/)
+- `alias t` とはしにくい（terraform で使用中）のが玉に瑕
+
+## history
+
+### 2024-06
+
+- [モダンなタスクランナーを求めて task (taskfile.dev) を使うまでの軌跡](https://zenn.dev/raki/articles/2024-05-30_task_runner)


### PR DESCRIPTION
- 更新をサボらない
- Taskfile.dev が tools に入って
- make が代わりに hold 行き
- kind を platforms に追加
- ローカルの python 環境を整理している関係で gen_json.py のシバンを python に