### PR TITLE
fix: check-yaml use allow-multiple-documents option in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
             path/to/file3.json
           )$
       - id: check-yaml
+        args:
+          - --allow-multiple-documents
       - id: check-toml
       - id: check-xml
       - id: detect-private-key


### PR DESCRIPTION
check-yaml で複数ドキュメントの yaml がエラーになるのを抑制できるオプションを使う。